### PR TITLE
Mac: Fix file dialog filters when filter doesn't start with '*'

### DIFF
--- a/src/gui/dialogs/qfiledialog_mac.mm
+++ b/src/gui/dialogs/qfiledialog_mac.mm
@@ -328,7 +328,8 @@ QT_USE_NAMESPACE
         }
     }
 
-    QString qtFileName = QT_PREPEND_NAMESPACE(qt_mac_NSStringToQString)(filename);
+    QString qtFileName
+        = QFileInfo(QT_PREPEND_NAMESPACE(qt_mac_NSStringToQString)(filename)).fileName();
     // No filter means accept everything
     bool nameMatches = mSelectedNameFilter->isEmpty();
     // Check if the current file name filter accepts the file:


### PR DESCRIPTION
Task-number: QTBUG-17326

Change-Id: Ie32f2807e64aa9c90b2e7d75adcd2aef67649225
(cherry picked from commit 1218a556210b38735af4bd108bf58f0305b961d6)
